### PR TITLE
add noping flag

### DIFF
--- a/netemd/cmd.go
+++ b/netemd/cmd.go
@@ -15,6 +15,7 @@ import (
 var Verbose bool
 var cfg *config.Config
 var cfgFile string
+var noPing bool
 
 var NetemPubCmd = &cobra.Command{
 	Use:   "TODO",
@@ -22,7 +23,7 @@ var NetemPubCmd = &cobra.Command{
 	Long: `TODO details...
 			Complete documentation is available at http://...`,
 	Run: func(cmd *cobra.Command, args []string) {
-		service.NetemPub(cfg)
+		service.NetemPub(cfg, noPing)
 		http.ListenAndServe(fmt.Sprintf(":%d", cfg.HTTPPort), nil)
 	},
 }
@@ -30,6 +31,7 @@ var NetemPubCmd = &cobra.Command{
 func init() {
 	cobra.OnInitialize(initConfig)
 	NetemPubCmd.Flags().StringVar(&cfgFile, "config", "", "config file (default is TODO)")
+	NetemPubCmd.Flags().BoolVarP(&noPing, "noping", "", false, "disable delay measurements")
 	NetemPubCmd.Flags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 }
 

--- a/netemd/service/service.go
+++ b/netemd/service/service.go
@@ -106,8 +106,10 @@ func hpingPoller(cfg *config.Config) {
 	}
 }
 
-func NetemPub(cfg *config.Config) {
+func NetemPub(cfg *config.Config, noPing bool) {
 	initExpVars(cfg)
 	go netemPoller(cfg)
-	go hpingPoller(cfg)
+	if !noPing {
+		go hpingPoller(cfg)
+	}
 }


### PR DESCRIPTION
I'm using a testbed based on [spinbit-testbed](https://github.com/mami-project/spinbit-testbed) for loss measurements with few bits. I would like to get accurate loss counts for my generated traffic from `netem-pub`, but don't need any delay measurement. Thus, I needed the option to turn ping off such that no ping packets go towards the loss count.

If you feel the addition of this flag is useful in general, please feel free to comment or accept.
